### PR TITLE
Feat: proper math

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "watch:labextension": "jupyter labextension watch ."
     },
     "dependencies": {
-        "@agoose77/jupyterlab-markup": "^2.0.0",
+        "@agoose77/jupyterlab-markup": "^2.1.0-alpha.0",
         "@jupyterlab/application": "^3.0.0",
         "markdown-it": "^12.2.3",
         "markdown-it-amsmath": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "dependencies": {
         "@agoose77/jupyterlab-markup": "^2.0.0",
         "@jupyterlab/application": "^3.0.0",
-        "katex": "^0.14.0",
         "markdown-it": "^12.2.3",
         "markdown-it-amsmath": "^0.3.1",
         "markdown-it-docutils": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-myst",
-    "version": "0.1.7-a5",
+    "version": "0.1.7-alpha.6",
     "description": "A Myst renderer for JupyterLab",
     "keywords": [
         "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 dependencies = [
     "jupyter_server>=1.6,<2",
-    "jupyterlab-markup~=2.1.0a0",
+    "jupyterlab-markup>=2.1.0a0",
     "importlib_metadata"
 ]
 dynamic = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 dependencies = [
     "jupyter_server>=1.6,<2",
-    "jupyterlab-markup~=2.0",
+    "jupyterlab-markup~=2.1.0a0",
     "importlib_metadata"
 ]
 dynamic = [

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+# setup.py shim for use with versions of JupyterLab that require
+# it for extensions.
+__import__("setuptools").setup()

--- a/src/builtins/docutils/index.ts
+++ b/src/builtins/docutils/index.ts
@@ -1,7 +1,6 @@
 import { simpleMarkdownItPlugin } from '@agoose77/jupyterlab-markup';
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
 import type MarkdownIt from 'markdown-it';
-import katex from 'katex';
 
 import { PACKAGE_NS } from '../../tokens';
 import { EvalRole } from './roles';
@@ -79,23 +78,13 @@ export const docutils: JupyterFrontEndPlugin<void> = simpleMarkdownItPlugin(
         md.renderer.rules['math_block'] = (tokens, idx) => {
           const token = tokens[idx];
           const content = wrapDisplayMath(token.content.trim());
-          const rendered = katex.renderToString(content, {
-            displayMode: true,
-            throwOnError: false,
-            output: 'htmlAndMathml'
-          });
-          return `<div class="${token.attrGet('class')}">${rendered}</div>`;
+          return `<div class="${token.attrGet('class')}">$$${content}$$</div>`;
         };
 
         md.renderer.rules['math_inline'] = (tokens, idx) => {
           const token = tokens[idx];
           const content = token.content.trim();
-          const rendered = katex.renderToString(content, {
-            displayMode: false,
-            throwOnError: false,
-            output: 'htmlAndMathml'
-          });
-          return `<span class="${token.attrGet('class')}">${rendered}</span>`;
+          return `<span class="${token.attrGet('class')}">$${content}$</span>`;
         };
       }
 

--- a/src/builtins/docutils/index.ts
+++ b/src/builtins/docutils/index.ts
@@ -8,33 +8,9 @@ import { EvalDirectiveAny, EvalFigureDirective } from './directives';
 
 import {
   directivesDefault,
-  rolesDefault,
-  IOptions
+  IOptions,
+  rolesDefault
 } from 'markdown-it-docutils';
-
-function splitPart(text: string): string {
-  if (text.includes('\\\\')) {
-    return `\\begin{split}${text}\\end{split}`;
-  } else {
-    return text;
-  }
-}
-
-function wrapDisplayMath(text: string): string {
-  const parts = text.split('\n\n');
-  const split_parts = parts.map(splitPart);
-
-  if (parts.length === 1) {
-    return `\\begin{equation}\\begin{split}${parts[0]}\\end{split}\\end{equation}\n`;
-  } else if (parts.length > 1) {
-    let result = ' \\begin{align}\\begin{aligned}';
-    result += split_parts.join('\\\\');
-    result += ' \\begin{aligned}\\end{align}';
-    return result;
-  } else {
-    return split_parts.join('////');
-  }
-}
 
 /**
  * Provides docutils roles and directives
@@ -73,19 +49,6 @@ export const docutils: JupyterFrontEndPlugin<void> = simpleMarkdownItPlugin(
           roles: roles,
           directives: directives
         });
-
-        // Add renderers to MarkdownIt
-        md.renderer.rules['math_block'] = (tokens, idx) => {
-          const token = tokens[idx];
-          const content = wrapDisplayMath(token.content.trim());
-          return `<div class="${token.attrGet('class')}">$$${content}$$</div>`;
-        };
-
-        md.renderer.rules['math_inline'] = (tokens, idx) => {
-          const token = tokens[idx];
-          const content = token.content.trim();
-          return `<span class="${token.attrGet('class')}">$${content}$</span>`;
-        };
       }
 
       return [wrappedDocutilsPlugin];

--- a/src/builtins/index.ts
+++ b/src/builtins/index.ts
@@ -2,8 +2,15 @@ import { frontMatter } from './front-matter';
 import { docutils } from './docutils';
 import { amsmath } from './amsmath';
 import { mystExtras } from './myst-extras';
+import { sphinxMath } from './sphinx-math';
 
 /**
  * Builtin plugins provided by this labextension
  */
-export const BUILTINS = [frontMatter, docutils, amsmath, mystExtras];
+export const BUILTINS = [
+  frontMatter,
+  docutils,
+  amsmath,
+  mystExtras,
+  sphinxMath
+];

--- a/src/builtins/sphinx-math.ts
+++ b/src/builtins/sphinx-math.ts
@@ -1,0 +1,69 @@
+import { simpleMarkdownItPlugin } from '@agoose77/jupyterlab-markup';
+import { JupyterFrontEndPlugin } from '@jupyterlab/application';
+import MarkdownIt from 'markdown-it';
+
+import { PACKAGE_NS } from '../tokens';
+
+function splitPart(text: string): string {
+  if (text.includes('\\\\')) {
+    return `\\begin{split}${text}\\end{split}`;
+  } else {
+    return text;
+  }
+}
+
+export function wrapDisplayMath(text: string): string {
+  const parts = text.split('\n\n');
+  const split_parts = parts.map(splitPart);
+
+  // Allow multiline equations using split
+  if (parts.length === 1) {
+    return `\\begin{equation}\\begin{split}${parts[0]}\\end{split}\\end{equation}\n`;
+  }
+  // Allow aligned equations with aligned
+  else if (parts.length > 1) {
+    let result = ' \\begin{align}\\begin{aligned}';
+    result += split_parts.join('\\\\\n');
+    result += ' \\end{aligned}\\end{align}';
+    return result;
+  } else {
+    return split_parts.join('////');
+  }
+}
+
+/**
+ * Provides Sphinx math-environment support
+ */
+export const sphinxMath: JupyterFrontEndPlugin<void> = simpleMarkdownItPlugin(
+  PACKAGE_NS,
+  {
+    id: 'sphinx-display-math',
+    title: 'Sphinx Display Math',
+    description:
+      'Plugin for transforming display math using the Sphinx displaymath rules',
+    documentationUrls: {},
+    examples: {
+      'Multi-line Equation ': '$$\nx = y \\\\ + mx + c\n$$\n',
+      'Multiple Equations ': '$$x = y\n\ny + z = 2$$\n'
+    },
+    plugin: async () => {
+      return [
+        (md: MarkdownIt) => {
+          md.core.ruler.push('sphinx-displaymath', state => {
+            state.tokens.forEach(token => {
+              if (token.type === 'math_block') {
+                token.content = wrapDisplayMath(token.content);
+              } else if (token.type === 'inline') {
+                token.children.forEach(token => {
+                  if (token.type === 'math_inline_double') {
+                    token.content = wrapDisplayMath(token.content);
+                  }
+                });
+              }
+            });
+          });
+        }
+      ];
+    }
+  }
+);

--- a/style/base.css
+++ b/style/base.css
@@ -1,5 +1,4 @@
 @import 'markdown-it-docutils';
-@import 'katex/dist/katex.css';
 
 /* Use theme colours */
 :root {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1695,11 +1695,6 @@ commander@7, commander@^7.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
-commander@^8.0.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
-  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
-
 commander@~6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.0.0.tgz#2b270da94f8fb9014455312f829a1129dbf8887e"
@@ -4099,13 +4094,6 @@ jws@^3.2.2:
   dependencies:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
-
-katex@^0.14.0:
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/katex/-/katex-0.14.1.tgz#e7e2f568d19739593ef169f206d19907d51d5f5d"
-  integrity sha512-CweL2N9NLce3SfRonyqRYahz7skD2/VVhGGrh+d3IytKjKEGg1vwFarLrtCOakwVJoqZxldkEr0eUkUwGkAOTw==
-  dependencies:
-    commander "^8.0.0"
 
 keygrip@~1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This PR adds *better* math rendering for JupyterLab by reformatting markup to be parsed by the ILatexTypesetter. This means we don't have to ship *another* math renderer, and in general seems like it will play better with MathJax et al.

We also lose the math renderer implementation in `docutils`, relying instead on the `dollarmath` implementation. This will change once things become standardised.