### PR TITLE
fix: use selector for JupyterLab dark mode

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 const colors = require('tailwindcss/colors');
 
 module.exports = {
-  darkMode: 'class',
+  darkMode: ['class', '[data-jp-theme-light="false"]'],
   content: [
     './src/**/*.{js,ts,jsx,tsx}',
     'node_modules/myst-to-react/dist/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
Fixes #67 and fixes #84