### PR TITLE
🐛 Show citations with an error

### DIFF
--- a/src/citations.tsx
+++ b/src/citations.tsx
@@ -1,0 +1,20 @@
+import type { Plugin } from 'unified';
+import type { Root } from 'myst-spec';
+import type { GenericNode } from 'myst-common';
+import { selectAll } from 'unist-util-select';
+
+/**
+ * Add fake children to the citations
+ */
+export async function addCiteChildrenTransform(tree: Root): Promise<void> {
+  const links = selectAll('cite', tree) as GenericNode[];
+  links.forEach(async cite => {
+    if (cite.children && cite.children.length > 0) return;
+    cite.error = true;
+    cite.children = [{ type: 'text', value: cite.label }];
+  });
+}
+
+export const addCiteChildrenPlugin: Plugin<[], Root, Root> = () => tree => {
+  addCiteChildrenTransform(tree);
+};

--- a/src/myst.ts
+++ b/src/myst.ts
@@ -33,6 +33,7 @@ import { StaticNotebook } from '@jupyterlab/notebook';
 import { getCellList } from './utils';
 import { imageUrlSourceTransform } from './images';
 import { internalLinksPlugin } from './links';
+import { addCiteChildrenPlugin } from './citations';
 
 const evalRole: RoleSpec = {
   name: 'eval',
@@ -125,6 +126,7 @@ export function parseContent(
     .use(footnotesPlugin, { references })
     .use(resolveReferencesPlugin, { state })
     .use(internalLinksPlugin, { notebook })
+    .use(addCiteChildrenPlugin)
     .use(keysPlugin)
     .runSync(mdast as any, file);
 


### PR DESCRIPTION
This now shows an error for the missing citations at the moment.

A future iteration will actually load these up from bibtex!

For example, from `` {cite:p}`ok` `` instead of showing `()` now shows:
![image](https://user-images.githubusercontent.com/913249/220685985-eb60ae03-f2e3-463a-8917-571f3101d39e.png)
