### PR TITLE
🃏 Apply classnames for links

### DIFF
--- a/src/links.tsx
+++ b/src/links.tsx
@@ -76,7 +76,7 @@ export const linkFactory =
       );
     }, [ref, url]);
     return (
-      <a href={url} ref={ref}>
+      <a href={url} ref={ref} className={props.className}>
         {props.children}
       </a>
     );


### PR DESCRIPTION
This fixes link-cards, which had dropped their external styles.

For example the link cards:

![image](https://user-images.githubusercontent.com/913249/226972622-9c8bf11c-2bda-440d-8d79-bab1b350d8e2.png)
