### PR TITLE
:broom: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Report a problem 🐛
+description: Problem reports are for when something behaves incorrectly, or differently from how you'd expect.
+labels: [bug]
+body:
+- type: textarea
+  id: describe
+  attributes:
+    label: Describe the bug
+    description: |
+      Provide a short description (one or two sentences) about the problem. What did you expect to happen, and what is actually happening?
+
+      If possible, provide screenshots or error messages that you've encountered.
+    value: |
+      **context**
+      When I do ___.
+      
+      **expectation**
+      I expected ___ to occur.
+      
+      **bug**
+      But instead ___ happens
+      Here's an error message I ran into...
+
+      **problem**
+      This is a problem for people doing ___ because ___.
+      
+  validations:
+    required: true
+
+- type: textarea
+  id: reproduce
+  attributes:
+    label: Reproduce the bug
+    description: |
+      Provide information that others may use to re-produce this behavior.
+      For example:
+      
+      - Step-by-step instructions that others can follow.
+      - Links to a website that demonstrates the bug.
+      - Information about certain conditions that the bug pops up.
+
+    placeholder: |
+      1. Go to '...'
+      2. Click on '....'
+      3. Scroll down to '....'
+      4. See error
+  validations:
+    required: true
+
+- type: textarea
+  id: environment
+  attributes:
+    label: List your environment
+    description: |
+      List the environment needed to reproduce the error.
+      Here are a few ideas:
+
+      - The output of:      
+        ```bash
+        jupyter server extension list
+        jupyter labextension list
+        pip list
+        ```
+      - The version of Python you're using.
+      - Your operating system
+      - Versions of any other relevant tools you're using.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Questions or general discussion with the community
+    url: https://github.com/executablebooks/meta/discussions
+    about: Use our Community Forum for general conversations that aren't meant for actionable Issues.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,47 @@
+# Inspired by
+# - https://www.backhub.co/blog/best-practices-for-using-github-issues
+# - https://medium.com/nyc-planning-digital/writing-a-proper-github-issue-97427d62a20f
+# - https://wiredcraft.com/blog/how-we-write-our-github-issues/
+name: Request an enhancement 💡
+description: Suggest an idea for this project
+labels: [enhancement]
+body:
+- type: textarea
+  id: context
+  attributes:
+    label: Context
+    description: |
+      - Provide background to help others understand this issue.
+      - Describe the problem or need you'd like to address.
+  validations:
+    required: true
+
+
+- type: textarea
+  id: proposal
+  attributes:
+    label: Proposal
+    description: |
+      - A simple and clear description of what you're proposing.
+      - Ideas or constraints for how to implement this proposal
+      - Important considerations to think about or discuss
+  validations:
+    required: false
+
+
+- type: textarea
+  id: tasks
+  attributes:
+    label: Tasks and updates
+    description: |
+      Use this area to track ongoing work and to-do items.
+      The more specific the better.
+
+      _If you can't think of anything then just leave this blank and we can fill it in later! This can be filled in as we understand more about an issue._
+
+    placeholder: |
+      - [ ] Discuss and decide on what to do...
+      - [ ] Implement partial feature A...
+
+  validations:
+    required: false


### PR DESCRIPTION
Currently our issue templates are inherited from the parent GitHub organisation repository. This PR adds our own minimally modified versions of these templates to reflect jupyterlab-myst specific language.

Fixes #62 