### PR TITLE
🌉 Update images to work locally

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,6 +153,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Install missing dependencies
+        # On May 30, 2023 this wasn't included in the base try removing in future!
+        run: pip install typing_extensions
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
           ignore_links: 'https:\/\/mybinder\.org.*'

--- a/src/images.ts
+++ b/src/images.ts
@@ -6,7 +6,7 @@ import { AttachmentsResolver } from '@jupyterlab/attachments';
 
 type Options = {
   resolver: IRenderMime.IResolver | null;
-  cell: MarkdownCell;
+  cell?: MarkdownCell;
 };
 
 export async function imageUrlSourceTransform(
@@ -17,10 +17,18 @@ export async function imageUrlSourceTransform(
   await Promise.all(
     images.map(async image => {
       if (!image || !image.url) return;
-      const resolver = new AttachmentsResolver({
-        parent: opts.resolver ?? undefined,
-        model: opts.cell.model.attachments
-      });
+      if (!opts.resolver) {
+        console.warn(
+          'No resolver supplied to `imageUrlSourceTransform`, local images may not work.'
+        );
+        return;
+      }
+      const resolver = opts.cell
+        ? new AttachmentsResolver({
+            parent: opts.resolver ?? undefined,
+            model: opts.cell?.model.attachments
+          })
+        : opts.resolver;
       const path = await resolver.resolveUrl(image.url);
       if (!path) return;
       const url = await resolver.getDownloadUrl(path);

--- a/src/myst.ts
+++ b/src/myst.ts
@@ -32,7 +32,7 @@ import { internalLinksPlugin } from './links';
 import { addCiteChildrenPlugin } from './citations';
 import { evalRole } from './roles';
 
-export function markdownParse(text: string): Root {
+export function markdownParse(text: string, inNotebook = true): Root {
   const mdast = mystParse(text, {
     directives: [
       cardDirective,
@@ -56,9 +56,11 @@ export function markdownParse(text: string): Root {
       }
     })
     .runSync(mdast as any);
-  // Lift children out of blocks for the next step
-  // We are working here as one cell at a time
-  liftChildren(mdast, 'block');
+  if (inNotebook) {
+    // If in the notebook, lift children out of blocks for the next step
+    // We are working here as one cell at a time
+    liftChildren(mdast, 'block');
+  }
   return mdast as Root;
 }
 

--- a/style/preflight.css
+++ b/style/preflight.css
@@ -29,4 +29,9 @@
 
 .myst figure img {
   display: block;
+  max-width: 100%;
+}
+
+.myst img {
+  max-width: 100%;
 }

--- a/style/preflight.css
+++ b/style/preflight.css
@@ -27,11 +27,11 @@
   background-image: none; /* 2 */
 }
 
-.myst figure img {
-  display: block;
+.myst img {
   max-width: 100%;
 }
 
-.myst img {
+.myst figure img {
+  display: block;
   max-width: 100%;
 }


### PR DESCRIPTION
This enables local images to work in the markdown preview.

![image](https://github.com/executablebooks/jupyterlab-myst/assets/913249/a14f85b7-5fc2-49be-8262-b0160b7adf8d)

