### PR TITLE
Add basic backwards compatibility

### DIFF
--- a/src/MySTMarkdownCell.tsx
+++ b/src/MySTMarkdownCell.tsx
@@ -26,6 +26,11 @@ export class MySTMarkdownCell
     (this.model as unknown as MarkdownCellModel).onTrustedChanged = () =>
       this.onTrustedChanged();
 
+    if (!this.renderer) {
+      // This is a backwards compatible 3.6 change
+      (this as any).renderer = new RenderedMySTMarkdown({} as any);
+    }
+
     this.mystRenderer.fragmentContext = {
       requestUpdate: _ => this.onRendererRequestUpdate(),
       getSource: () => this.model.sharedModel.getSource(),
@@ -41,7 +46,8 @@ export class MySTMarkdownCell
   }
 
   protected restoreExpressionsFromMetadata() {
-    const expressions = this.model.getMetadata(metadataSection);
+    // In 3.6 this is not a function
+    const expressions = this.model.getMetadata?.(metadataSection);
     if (expressions !== undefined) {
       this.mystRenderer.onExpressionsUpdated({
         expressions: expressions,

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -123,6 +123,7 @@ export async function notebookCellExecuted(
     cell.model.setMetadata(metadataSection, expressions);
     cell.model.trusted = true;
   } else {
-    cell.model.deleteMetadata(metadataSection);
+    // In 3.6 this is not a function
+    cell.model.deleteMetadata?.(metadataSection);
   }
 }


### PR DESCRIPTION
This adds basic compatibility for JupyterLab-v3.6.

It doesn't add the expression renderer, and I am not sure we should even try. But it does actually render myst again, which is probably good that it isn't a fully broken experience.