### PR TITLE
🎨 Update HTML styles for buttons, kbd, etc.

### DIFF
--- a/src/renderers.tsx
+++ b/src/renderers.tsx
@@ -18,11 +18,12 @@ export const renderers: Record<string, NodeRenderer> = {
     if (sanitizer !== undefined) {
       return (
         <span
+          className="jp-RenderedHTMLCommon not-prose"
           dangerouslySetInnerHTML={{ __html: sanitizer.sanitize(node.value) }}
         ></span>
       );
     } else {
-      return <pre> {`${node.value}`} </pre>;
+      return <pre>{node.value}</pre>;
     }
   }
 };

--- a/style/preflight.css
+++ b/style/preflight.css
@@ -5,7 +5,10 @@
 
 /* This is a highly simplified version of https://tailwindcss.com/docs/preflight to work with JupyterLab */
 
-.myst * {
+.myst
+  :where(*):not(
+    :where([class~='jp-RenderedHTMLCommon'], [class~='jp-RenderedHTMLCommon'] *)
+  ) {
   box-sizing: border-box; /* 1 */
   border-width: 0; /* 2 */
   border-style: solid; /* 2 */
@@ -21,17 +24,26 @@
 2. Remove default button styles.
 */
 
-.myst button {
+.myst
+  :where(button):not(
+    :where([class~='jp-RenderedHTMLCommon'], [class~='jp-RenderedHTMLCommon'] *)
+  ) {
   -webkit-appearance: button; /* 1 */
   background-color: transparent; /* 2 */
   background-image: none; /* 2 */
 }
 
-.myst img {
+.myst
+  :where(img):not(
+    :where([class~='jp-RenderedHTMLCommon'], [class~='jp-RenderedHTMLCommon'] *)
+  ) {
   max-width: 100%;
 }
 
-.myst figure img {
+.myst
+  :where(figure img):not(
+    :where([class~='jp-RenderedHTMLCommon'], [class~='jp-RenderedHTMLCommon'] *)
+  ) {
   display: block;
   max-width: 100%;
 }


### PR DESCRIPTION
This restores `jp-RenderedHTMLCommon` class for raw HTML elements and modifies the `preflight` to ignore these nested spans. This means that `kbd`, `button` etc. will look the same as the original Jupyter content.


For example, from #64:

![image](https://github.com/executablebooks/jupyterlab-myst/assets/913249/70e7986b-ce70-402c-b6a6-e90ed4489e46)