### PR TITLE
use not checked instead of == to hopefully make the linter happy?

### DIFF
--- a/src/components/listItem.tsx
+++ b/src/components/listItem.tsx
@@ -45,16 +45,16 @@ export function ListItem({
   line?: number;
   children?: any[];
 }): JSX.Element {
-  if (checked !== true && checked !== false) {
+  if (typeof checked === 'boolean') {
     return (
-      <li>
+      <TaskItem checked={checked} line={line}>
         <MyST ast={children} />
-      </li>
+      </TaskItem>
     );
   }
   return (
-    <TaskItem checked={checked} line={line}>
+    <li>
       <MyST ast={children} />
-    </TaskItem>
+    </li>
   );
 }

--- a/src/components/listItem.tsx
+++ b/src/components/listItem.tsx
@@ -45,7 +45,7 @@ export function ListItem({
   line?: number;
   children?: any[];
 }): JSX.Element {
-  if (checked == null) {
+  if (!checked) {
     return (
       <li>
         <MyST ast={children} />

--- a/src/components/listItem.tsx
+++ b/src/components/listItem.tsx
@@ -45,7 +45,7 @@ export function ListItem({
   line?: number;
   children?: any[];
 }): JSX.Element {
-  if (!checked) {
+  if (checked !== true && checked !== false) {
     return (
       <li>
         <MyST ast={children} />


### PR DESCRIPTION
Was just looking at https://github.com/executablebooks/jupyterlab-myst/commit/2b288cdd08394575aa2d87c0bc55caed9f3254a4 and it looks like a nice fix, except it makes the `linter` unhappy because it does not like the `==` operator. 

For various reasons, most Javascript style guides will discourage the use of `==` since the rules for fuzzy equality in javascript can be a bit obscure. Here I try changing that to a `!checked` which should do the same thing - i.e. check if the `checked` variable is `falsey` - so that would be true for `null` or `undefined`, which I think was the intention behind the `==` ? Am not fully sure how to test this, but I'll try - if anyone is able to verify though, I do hope this both fixes the issue and makes the linter happy.