### PR TITLE
FIX: use `linkify` in parser

### DIFF
--- a/src/myst.ts
+++ b/src/myst.ts
@@ -54,6 +54,7 @@ export interface IMySTExpressionsState {
 export function markdownParse(text: string): Root {
   const parseMyst = (content: string) => {
     return mystParse(content, {
+      markdownit: { linkify: true },
       directives: [
         cardDirective,
         gridDirective,


### PR DESCRIPTION
Closes #219