### PR TITLE
Update base.css for displaying link in blue

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -40,3 +40,15 @@
   padding: var(--jp-private-markdownviewer-padding);
   overflow: auto;
 }
+
+/* ─── Hard-code MyST links to blue ─────────────────────── */
+.jp-ThemedContainer .myst :where(a),
+.jp-ThemedContainer .myst :where(a):visited {
+  color: #0074d9 !important;      /* bright blue in all themes            */
+  text-decoration: none; /*underline !important; */
+}
+
+.jp-ThemedContainer .myst :where(a):hover {
+  text-decoration: none; /*underline !important; */ /* keep underline on hover        */
+}
+/* ───────────────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
Fixes #248 (EDIT)

I modified the base.css file adding extra CSS code to force the display of Myst links to appears light blue.
To install the fix in you python virtual environment, I followed these steps:

_I assume that you have a Python virtual environment with Jupyterlab and pip installed in it._


1 - Download or `git clone` my `jupyterlab-myst` fork repository https://github.com/tguilment/jupyterlab-myst (you can also get the original repository and do the changes yourself at https://github.com/jupyter-book/jupyterlab-myst)


2 - The goal will be to:
i) If not done, change the `jupyterlab-myst/style/base.css` file adding the theme you want at the end:
```C
/* Hard-code MyST links to light blue */
.jp-ThemedContainer .myst :where(a),
.jp-ThemedContainer .myst :where(a):visited {
  color: #0074d9 !important;      /* bright blue   */
  text-decoration: none; /*underline !important; */
}

.jp-ThemedContainer .myst :where(a):hover {
  text-decoration: none; /*underline !important; */ /* keep underline on hover        */
}
```
ii) Once this is done, activate your python virtual environment et `cd` inside `jupyterlab-myst`
iii) Install the package with `pip install -e .` (with `.` the current folder path to be `jupyterlab-myst`)
iv) Create dependencies and build the extension using the `jlpm` tool (should be already working when pip and jupyterlab are installed)
```bash
jlpm install
jlpm build
```
v) Update the Jupyterlab extension by executing `jupyter labextension develop . --overwrite`

Now, when running Jupyterlab and refreshing the page, you should have light blue links.

Let me know how it goes.

Hope that helps.

- closes https://github.com/jupyter-book/jupyterlab-myst/issues/248