### PR TITLE
:link: Fix link styles

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -49,6 +49,7 @@
   text-decoration: none;
   font-weight: 400;
 }
+
 .jp-ThemedContainer
   .myst
   :where(a):not(:where([class~='not-prose'], [class~='not-prose'] *)):hover {

--- a/ui-tests/tests/notebooks/typography.ipynb
+++ b/ui-tests/tests/notebooks/typography.ipynb
@@ -119,7 +119,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.13.7"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
This PR fixes #248 and replaces #268. Thanks @tguilment for your PR — we settled on the same solutions. I tweaked the styling a tad.

This is not an ideal fix — we should address the root cause, but it needs some thought, as I suspect we just need to use a shadow DOM here.